### PR TITLE
Allow opening and closing quotation marks in QuoteArg

### DIFF
--- a/src/main/kotlin/me/jakejmattson/discordkt/api/arguments/QuoteArg.kt
+++ b/src/main/kotlin/me/jakejmattson/discordkt/api/arguments/QuoteArg.kt
@@ -16,18 +16,22 @@ open class QuoteArg(override val name: String = "Quote",
     override suspend fun convert(arg: String, args: List<String>, event: CommandEvent<*>): ArgumentResult<String> {
         val quotationMark = '"'
 
-        if (!arg.startsWith(quotationMark))
+        // Handles Apple phone quotation marks
+        val rightOpeningQuotationMark = '“'
+        val leftClosingQuotationMark = '”'
+
+        if (!arg.startsWith(quotationMark) && !arg.startsWith(rightOpeningQuotationMark))
             return Error("No opening quotation mark")
 
-        val rawQuote = if (!arg.endsWith(quotationMark))
+        val rawQuote = if (!arg.endsWith(quotationMark) && !arg.endsWith(leftClosingQuotationMark))
             args.takeUntil { !it.endsWith(quotationMark) }.joinToString(" ")
         else
             arg
 
-        if (!rawQuote.endsWith(quotationMark))
+        if (!rawQuote.endsWith(quotationMark) && !rawQuote.endsWith(leftClosingQuotationMark))
             return Error("No closing quotation mark")
 
-        val quote = rawQuote.trim(quotationMark)
+        val quote = rawQuote.trim(quotationMark, rightOpeningQuotationMark, leftClosingQuotationMark)
         val consumedCount = quote.split(" ").size
 
         return Success(quote, consumedCount)

--- a/src/test/kotlin/arguments/QuoteArg.kt
+++ b/src/test/kotlin/arguments/QuoteArg.kt
@@ -9,7 +9,8 @@ class QuoteArgTest : ArgumentTestFactory {
     override val validArgs = listOf(
         "\"\"" to "",
         "\"Hello\"" to "Hello",
-        "\"Hello World\"" to "Hello World"
+        "\"Hello World\"" to "Hello World",
+        "“Hello World”" to "Hello World"
     )
 
     override val invalidArgs = listOf(
@@ -20,6 +21,7 @@ class QuoteArgTest : ArgumentTestFactory {
         "\"Leading Multiple",
         "Trailing Multiple\"",
         "I\"nterrupt\"",
-        "\"Interrup\"t"
+        "\"Interrup\"t",
+        "”Invalid order“"
     )
 }


### PR DESCRIPTION
I discovered that when typing on Apple phones, it uses opening and closing quotation marks.  The QuoteArg is not aware of this and therefore makes QuoteArg commands unusable on Apple phones.  This PR solves that by adding the opening and closing quotation marks to the checks for quotation marks.

I am fairly new to Kotlin (and writing tests) so please let me know if there's anything that needs added or changed.