### PR TITLE
Made the listener catch and ignore IllegalArgumentException

### DIFF
--- a/src/main/kotlin/me/jakejmattson/discordkt/api/dsl/Bot.kt
+++ b/src/main/kotlin/me/jakejmattson/discordkt/api/dsl/Bot.kt
@@ -93,7 +93,8 @@ public class Bot(private val token: String, private val packageName: String) {
                 intents = intents + intentsOf<MessageCreateEvent>() + intentsOf<InteractionCreateEvent>(),
                 entitySupplyStrategy = entitySupplyStrategy,
                 prefix = prefixFun,
-                mentionEmbed = mentionEmbedFun
+                mentionEmbed = mentionEmbedFun,
+                ignoreIllegalArgumentExceptionInListeners = ignoreIllegalArgumentExceptionInListeners
             )
         }
 

--- a/src/main/kotlin/me/jakejmattson/discordkt/api/dsl/Configuration.kt
+++ b/src/main/kotlin/me/jakejmattson/discordkt/api/dsl/Configuration.kt
@@ -36,6 +36,7 @@ public data class BotConfiguration(
     val theme: dev.kord.common.Color?,
     val intents: Intents,
     val entitySupplyStrategy: EntitySupplyStrategy<*>,
+    val ignoreIllegalArgumentExceptionInListeners: Boolean,
 
     internal val prefix: suspend (DiscordContext) -> String,
     internal val mentionEmbed: (suspend EmbedBuilder.(DiscordContext) -> Unit)?,
@@ -54,15 +55,18 @@ public data class BotConfiguration(
  * @property intents Additional gateway [Intents] to register manually.
  * @property entitySupplyStrategy [EntitySupplyStrategy] for use in Kord cache.
  */
-public data class SimpleConfiguration(var allowMentionPrefix: Boolean = true,
-                                      var showStartupLog: Boolean = true,
-                                      var generateCommandDocs: Boolean = true,
-                                      var recommendCommands: Boolean = true,
-                                      var enableSearch: Boolean = true,
-                                      var commandReaction: DiscordEmoji? = Emojis.eyes,
-                                      var theme: Color? = null,
-                                      var intents: Intents = Intents.none,
-                                      var entitySupplyStrategy: EntitySupplyStrategy<*> = EntitySupplyStrategy.cacheWithCachingRestFallback) {
+public data class SimpleConfiguration(
+    var allowMentionPrefix: Boolean = true,
+    var showStartupLog: Boolean = true,
+    var generateCommandDocs: Boolean = true,
+    var recommendCommands: Boolean = true,
+    var enableSearch: Boolean = true,
+    var commandReaction: DiscordEmoji? = Emojis.eyes,
+    var theme: Color? = null,
+    var intents: Intents = Intents.none,
+    var entitySupplyStrategy: EntitySupplyStrategy<*> = EntitySupplyStrategy.cacheWithCachingRestFallback,
+    var ignoreIllegalArgumentExceptionInListeners: Boolean = true
+) {
     @PublishedApi
     internal var permissionLevels: List<Enum<*>> = listOf(DefaultPermissions.EVERYONE)
 

--- a/src/main/kotlin/me/jakejmattson/discordkt/api/dsl/Listeners.kt
+++ b/src/main/kotlin/me/jakejmattson/discordkt/api/dsl/Listeners.kt
@@ -38,7 +38,13 @@ public data class ListenerBuilder(val discord: Discord) {
             InternalLogger.error("${T::class.simplerName} missing intent: $intentNames")
 
         discord.kord.on<T> {
-            listener(this)
+            try {
+                listener(this)
+            } catch (up: IllegalArgumentException) {
+                if (!discord.configuration.ignoreIllegalArgumentExceptionInListeners) {
+                    throw up
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Currently code that wants to check conditions in listeners need to do the following

```kotlin
on<ReactionAddEvent> {
        if (user.isSelf()) return@on
        if (emoji != wastebasket) return@on
        if (channelId == config.roleChannel) return@on
        // snip
}
```

This could be written cleaner by using `require` and `requireNotNull`
```kotlin
on<ReactionAddEvent> {
    require(!user.isSelf())
    require(emoji == wastebucket)
    require(channelId != config.roleChannel)
    // snip
}
```

This change makes it so (by default) any `IllegalArgumentException`'s thrown in a handler are silently caught and ignored.

The config value to control this is `ignoreIllegalArgumentExceptionInListeners` when set to false, it will rethrow the exception, generating the current behaviour. 