### PR TITLE
Fix invite regex call and create tests for invite regex

### DIFF
--- a/src/main/kotlin/me/jakejmattson/discordkt/extensions/MessageExtensions.kt
+++ b/src/main/kotlin/me/jakejmattson/discordkt/extensions/MessageExtensions.kt
@@ -12,6 +12,11 @@ import kotlinx.coroutines.flow.count
 public fun Message.containsInvite(): Boolean = content.containsInvite()
 
 /**
+ * Find all invites in this message.
+ */
+public fun Message.getInvites(): List<String> = content.getInvites()
+
+/**
  * Checks if this message contains a URL.
  */
 public fun Message.containsURL(): Boolean = content.containsURl()

--- a/src/main/kotlin/me/jakejmattson/discordkt/extensions/StringExtensions.kt
+++ b/src/main/kotlin/me/jakejmattson/discordkt/extensions/StringExtensions.kt
@@ -29,7 +29,12 @@ public fun String.containsURl(): Boolean = urlRegexes.any { replace("\n", "").co
  * Whether this string matches the invite regex.
  * @sample me.jakejmattson.discordkt.extensions.inviteRegex
  */
-public fun String.containsInvite(): Boolean = inviteRegex.matches(this)
+public fun String.containsInvite(): Boolean = inviteRegex.containsMatchIn(this)
+
+/**
+ * Find all invites in this string.
+ */
+public fun String.getInvites(): List<String> = inviteRegex.findAll(this).map { it.value }.toList()
 
 /**
  * Whether this string is a valid boolean value (true/false/t/f).

--- a/src/test/kotlin/regex/InviteRegex.kt
+++ b/src/test/kotlin/regex/InviteRegex.kt
@@ -1,0 +1,37 @@
+package regex
+
+import me.jakejmattson.discordkt.extensions.containsInvite
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class InviteRegexTest {
+    private val validInvites = listOf(
+        "https://discord.gg/discordkttest",
+        "https://discord.me/discordkttest",
+        "https://discord.io/discordkttest",
+        "https://discord.com/invite/discordkttest",
+        "https://www.discord.gg/discordkttest",
+        "https://www.discord.me/discordkttest",
+        "https://www.discord.io/discordkttest",
+        "https://www.discord.com/invite/discordkttest",
+        "lorem ipsum https://discord.gg/discordkttest lorem ipsum"
+    )
+
+    private val invalidInvites = listOf(
+        "https://discord.gg",
+        "https://discord.me",
+        "https://discord.io",
+        "https://discord.com"
+    )
+
+    @Test
+    fun testInvite() {
+        validInvites.forEach {
+            assertTrue(it.containsInvite())
+        }
+
+        invalidInvites.forEach {
+            assertTrue(!it.containsInvite())
+        }
+    }
+}


### PR DESCRIPTION
- Adds `getInvites()`
- Fixes `containsInvites()`
- Adds tests for invite regexes