### PR TITLE
Allow for a custom slf4j logger to be passed for internal logging

### DIFF
--- a/src/main/kotlin/me/jakejmattson/discordkt/dsl/Bot.kt
+++ b/src/main/kotlin/me/jakejmattson/discordkt/dsl/Bot.kt
@@ -118,8 +118,13 @@ public class Bot(private val token: String, private val packageName: String) {
                 entitySupplyStrategy = entitySupplyStrategy,
                 prefix = prefixFun,
                 mentionEmbed = mentionEmbedFun,
-                exceptionHandler = exceptionHandlerFun
+                exceptionHandler = exceptionHandlerFun,
+                logger = logger
             )
+        }
+
+        if (botConfiguration.logger != null) {
+            InternalLogger.logger = botConfiguration.logger
         }
 
         val kord = Kord(token) {

--- a/src/main/kotlin/me/jakejmattson/discordkt/dsl/Configuration.kt
+++ b/src/main/kotlin/me/jakejmattson/discordkt/dsl/Configuration.kt
@@ -12,6 +12,7 @@ import dev.kord.rest.builder.message.EmbedBuilder
 import dev.kord.x.emoji.DiscordEmoji
 import dev.kord.x.emoji.Emojis
 import me.jakejmattson.discordkt.commands.DiscordContext
+import org.slf4j.Logger
 
 /**
  * Contains all properties configured when the bot is created.
@@ -44,6 +45,7 @@ public data class BotConfiguration(
     val intents: Intents,
     val defaultPermissions: Permissions,
     val entitySupplyStrategy: EntitySupplyStrategy<*>,
+    val logger: Logger?,
 
     internal val prefix: suspend (DiscordContext) -> String,
     internal val mentionEmbed: Pair<String?, (suspend EmbedBuilder.(DiscordContext) -> Unit)?>,
@@ -81,4 +83,5 @@ public data class SimpleConfiguration(
     var intents: Intents = Intents.NONE,
     var defaultPermissions: Permissions = Permissions(Permission.UseApplicationCommands),
     var entitySupplyStrategy: EntitySupplyStrategy<*> = EntitySupplyStrategy.cacheWithCachingRestFallback,
+    var logger: Logger? = null
 )

--- a/src/main/kotlin/me/jakejmattson/discordkt/internal/utils/InternalLogger.kt
+++ b/src/main/kotlin/me/jakejmattson/discordkt/internal/utils/InternalLogger.kt
@@ -1,18 +1,39 @@
 package me.jakejmattson.discordkt.internal.utils
 
+import org.slf4j.Logger
 import kotlin.system.exitProcess
 
 @PublishedApi
 internal object InternalLogger {
+
+    private var loggerSet: Boolean = false
+    var logger: Logger? = null
+        set(value) {
+            field = value
+            loggerSet = true
+        }
+
     fun log(message: String) {
+        if (loggerSet) {
+            logger!!.info(message)
+            return
+        }
         println(message)
     }
 
     fun error(message: String) {
+        if (loggerSet) {
+            logger!!.error(message)
+            return
+        }
         System.err.println(message)
     }
 
     fun fatalError(message: String) {
+        if (loggerSet) {
+            logger!!.error("[FATAL] $message")
+            exitProcess(-1)
+        }
         System.err.println("[FATAL] $message")
         exitProcess(-1)
     }


### PR DESCRIPTION
Adds a logger param to bot configuration and sets a new value in InternalLogger to allow for a custom slf4j logger